### PR TITLE
[example/nrfconnect] Added updating ZCL cluster state to meet with ac…

### DIFF
--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -45,6 +45,7 @@ private:
     void CancelTimer(void);
 
     void DispatchEvent(AppEvent * event);
+    void UpdateClusterState();
 
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void FunctionHandler(AppEvent * aEvent);

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -44,6 +44,7 @@ private:
     void CancelTimer(void);
 
     void DispatchEvent(AppEvent * event);
+    void UpdateClusterState();
 
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void FunctionHandler(AppEvent * aEvent);


### PR DESCRIPTION
…tual light/lock state.

 #### Problem
Initial value of ZCL ON/OFF cluster is not defined,
while the lock/lighting is initially turned on in nRF Connect examples.

 #### Summary of Changes
* Added UpdateClusterState method called on the init and each completed
on/off action.
