### PR TITLE
  Extracted ESP32 Url encoding method to the common QRCodeUtil module. 

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -28,6 +28,7 @@
 #include "RendezvousDeviceDelegate.h"
 #include "ScreenManager.h"
 #include "WiFiWidget.h"
+#include "QRCodeUtil.h"
 #include "esp_heap_caps_init.h"
 #include "esp_log.h"
 #include "esp_netif.h"
@@ -430,48 +431,6 @@ std::string createSetupPayload()
     return result;
 };
 
-bool inRfc3986UnreservedChar(const char c)
-{
-    static const char unreserved[] = { '-', '.', '_', '~' };
-    return isalpha(c) || isdigit(c) || (strchr(unreserved, c) != NULL);
-}
-
-esp_err_t urlEncode(const char * src, size_t len, char * dest, size_t max_size)
-{
-    const char upper_xdigits[] = "0123456789ABCDEF";
-    size_t i = 0, j = 0;
-    for (i = 0; i < len; ++i)
-    {
-        unsigned char c = src[i];
-        if (inRfc3986UnreservedChar(c))
-        {
-            if ((j + 1) < max_size)
-            {
-                dest[j++] = c;
-            }
-            else
-            {
-                return ESP_FAIL;
-            }
-        }
-        else
-        {
-            if ((j + 3) < max_size)
-            {
-                dest[j++] = '%';
-                dest[j++] = upper_xdigits[c >> 4];
-                dest[j++] = upper_xdigits[(c & 0x0f)];
-            }
-            else
-            {
-                return ESP_FAIL;
-            }
-        }
-    }
-    dest[j] = '\0';
-    return ESP_OK;
-}
-
 static SecurePairingUsingTestSecret gTestPairing;
 
 } // namespace
@@ -543,8 +502,8 @@ extern "C" void app_main()
 
     {
         std::vector<char> qrCode(3 * qrCodeText.size() + 1);
-        err = urlEncode(qrCodeText.c_str(), qrCodeText.size(), qrCode.data(), qrCode.max_size());
-        if (err == ESP_OK)
+        err = EncodeQRCodeToUrl(qrCodeText.c_str(), qrCodeText.size(), qrCode.data(), qrCode.max_size());
+        if (err == CHIP_NO_ERROR)
         {
             ESP_LOGI(TAG, "Copy paste the below URL in a browser to see the QR CODE:\n\t%s?data=%s", QRCODE_BASE_URL,
                      qrCode.data());

--- a/examples/common/chip-app-server/QRCodeUtil.cpp
+++ b/examples/common/chip-app-server/QRCodeUtil.cpp
@@ -22,7 +22,11 @@
 
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 #include <support/logging/CHIPLogging.h>
+
+constexpr char qrCodeBaseUrl[] = "https://dhrishi.github.io/connectedhomeip/qrcode.html";
+constexpr char specialCharsUnreservedInRfc3986[] = "-._~";
 
 void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags)
 {
@@ -33,6 +37,16 @@ void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags)
     {
         ChipLogProgress(AppServer, "SetupPINCode: [%" PRIu32 "]", setupPinCode);
         ChipLogProgress(AppServer, "SetupQRCode:  [%s]", QRCode.c_str());
+
+        chip::Platform::ScopedMemoryBuffer<char> qrCodeBuffer;
+        const size_t qrCodeBufferMaxSize = 3 * QRCode.size() + 1;
+        qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
+        if (EncodeQRCodeToUrl(QRCode.c_str(), QRCode.size(), &qrCodeBuffer[0],
+                              qrCodeBufferMaxSize) == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(AppServer, "Copy paste the below URL in a browser to see the QR Code:\n\t%s?data=%s",
+                            qrCodeBaseUrl, &qrCodeBuffer[0]);
+        }
     }
     else
     {
@@ -71,6 +85,46 @@ CHIP_ERROR GetQRCode(uint32_t & setupPinCode, std::string & QRCode, chip::Rendez
     // generating payload
     err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase41Representation(QRCode);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err)));
+
+exit:
+    return err;
+}
+
+static inline bool isCharUnreservedInRfc3986(const char c)
+{
+    return isalpha(c) || isdigit(c) || (strchr(specialCharsUnreservedInRfc3986, c) != nullptr);
+}
+
+CHIP_ERROR EncodeQRCodeToUrl(const char * QRCode, size_t len, char * url, size_t maxSize)
+{
+    const char upperHexDigits[] = "0123456789ABCDEF";
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    size_t i = 0, j = 0;
+
+    VerifyOrExit(QRCode && url, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(len <= maxSize, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    for (i = 0; i < len; ++i)
+    {
+        unsigned char c = QRCode[i];
+        if (isCharUnreservedInRfc3986(c)) {
+
+            VerifyOrExit((j + 1) < maxSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+            url[j++] = c;
+
+        } else {
+
+            VerifyOrExit((j + 3) < maxSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+            url[j++] = '%';
+            url[j++] = upperHexDigits[c >> 4];
+            url[j++] = upperHexDigits[(c & 0x0f)];
+
+        }
+    }
+
+    url[j] = '\0';
 
 exit:
     return err;

--- a/examples/common/chip-app-server/include/QRCodeUtil.h
+++ b/examples/common/chip-app-server/include/QRCodeUtil.h
@@ -21,3 +21,4 @@
 
 void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags);
 CHIP_ERROR GetQRCode(uint32_t & setupPinCode, std::string & QRCode, chip::RendezvousInformationFlags rendezvousFlags);
+CHIP_ERROR EncodeQRCodeToUrl(const char * QRCode, size_t len, char * url, size_t maxSize);


### PR DESCRIPTION
 #### Problem
ESP32 platform has implemented module enabling generating url link to the webpage displaying QR code, what could be useful for other platforms not having displays.

 #### Summary of Changes
* Moved url encoding method from ESP32 to the common QRCodeUtil module.
* Refactored methods a bit, as they were bug prone (e.g. unreserved array was not /0 terminated and then strchr was using it).

 #### Fixes