### PR TITLE
Added removing specific SRP service before adding new one.

### DIFF
--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -18,6 +18,8 @@
 #include "lib/mdns/platform/Mdns.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <support/CodeUtils.h>
 
 using namespace ::chip::DeviceLayer;
 
@@ -42,14 +44,24 @@ const char * GetProtocolString(MdnsServiceProtocol protocol)
 
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
-    if (service == nullptr)
-        return CHIP_ERROR_INVALID_ARGUMENT;
+    CHIP_ERROR result = CHIP_NO_ERROR;
+
+    VerifyOrExit(service, result = CHIP_ERROR_INVALID_ARGUMENT);
 
     char serviceType[kMdnsTypeMaxSize + kMdnsProtocolTextMaxSize + 1];
     snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
 
-    return ThreadStackMgr().AddSrpService(service->mName, serviceType, service->mPort, service->mTextEntries,
-                                          service->mTextEntrySize);
+    // Try to remove service before adding it, as SRP doesn't allow to update existing services.
+    result = ThreadStackMgr().RemoveSrpService(service->mName, serviceType);
+
+    // Service should be successfully removed or not found (not exists).
+    VerifyOrExit((result == CHIP_NO_ERROR) || (result == Internal::MapOpenThreadError(OT_ERROR_NOT_FOUND)), );
+
+    result =
+        ThreadStackMgr().AddSrpService(service->mName, serviceType, service->mPort, service->mTextEntries, service->mTextEntrySize);
+
+exit:
+    return result;
 }
 
 CHIP_ERROR ChipMdnsStopPublish()


### PR DESCRIPTION
 #### Problem
SRP doesn't allow to update  services, so in case of registering multiple times the same service (e.g. because of updating its
record content) only first attempt will succeed and the following will end with OT_DUPLICATED result.

 #### Summary of Changes
* In MdnsImpl added removing specific service before adding it, to make sure that it won't exist in the moment of adding its the
most present version.
