### PR TITLE
[zephyr] Fixed defining thread stack for Matter thread

### DIFF
--- a/config/nrfconnect/app/sample-defaults.conf
+++ b/config/nrfconnect/app/sample-defaults.conf
@@ -25,6 +25,7 @@ CONFIG_PRINTK_SYNC=y
 CONFIG_ASSERT=y
 CONFIG_HW_STACK_PROTECTION=y
 CONFIG_SHELL=y
+CONFIG_FPU=y
 
 # Enable getting reboot reasons information
 CONFIG_HWINFO=y

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -174,7 +174,10 @@ void GenericPlatformManagerImpl_Zephyr<ImplClass>::EventLoopTaskMain(void * this
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StartEventLoopTask(void)
 {
-    const auto tid = k_thread_create(&mChipThread, mChipThreadStack, K_THREAD_STACK_SIZEOF(mChipThreadStack), EventLoopTaskMain,
+    if (!mChipThreadStack)
+        return CHIP_ERROR_WELL_UNINITIALIZED;
+
+    const auto tid = k_thread_create(&mChipThread, mChipThreadStack, CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE, EventLoopTaskMain,
                                      this, nullptr, nullptr, CHIP_DEVICE_CONFIG_CHIP_TASK_PRIORITY, 0, K_NO_WAIT);
 
 #ifdef CONFIG_THREAD_NAME

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
@@ -45,7 +45,7 @@ template <class ImplClass>
 class GenericPlatformManagerImpl_Zephyr : public GenericPlatformManagerImpl<ImplClass>
 {
 protected:
-    using ThreadStack = k_thread_stack_t[K_THREAD_STACK_LEN(CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE)];
+    using ThreadStack = k_thread_stack_t*;
 
     // Members for select() loop
     int mMaxFd;
@@ -65,7 +65,7 @@ protected:
     // Although defining thread stack as a class member is feasible it's discouraged according to
     // the Zephyr documentation (see remarks on K_THREAD_STACK_MEMBER macro). Therefore, this class
     // requires the stack reference to be passed in the constructor.
-    ThreadStack & mChipThreadStack;
+    ThreadStack mChipThreadStack;
     k_thread mChipThread;
 
     // ===== Methods that implement the PlatformManager abstract interface.
@@ -82,7 +82,7 @@ protected:
     CHIP_ERROR _Shutdown(void);
 
     // ===== Methods available to the implementation subclass.
-    explicit GenericPlatformManagerImpl_Zephyr(ThreadStack & stack) : mChipThreadStack(stack) {}
+    explicit GenericPlatformManagerImpl_Zephyr(ThreadStack stack) : mChipThreadStack(stack) {}
 
 private:
     // ===== Private members for use by this class only.

--- a/src/platform/Zephyr/PlatformManagerImpl.h
+++ b/src/platform/Zephyr/PlatformManagerImpl.h
@@ -67,7 +67,7 @@ private:
     System::Clock::Timestamp mStartTime      = System::Clock::kZero;
     uint32_t mSavedOperationalHoursSinceBoot = 0;
 
-    explicit PlatformManagerImpl(ThreadStack & stack) : Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>(stack) {}
+    explicit PlatformManagerImpl(ThreadStack stack) : Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>(stack) {}
 
     static PlatformManagerImpl sInstance;
 };


### PR DESCRIPTION
#### Problem
By the way of enabling hardware FPU it turned out that we use
wrong Zephyr macro to define thread stack size and it may happen
that it will not be consistent with exact thread stack size.

#### Change overview
* Removed using K_THREAD_STACK_LEN macro
* Changed ThreadStack to be pointer on k_thread_stack_t, as Zephyr
API doesn't expose API to calculate aligned Thread stack size
based on desired stack size
* Aligned other methods API to ThreadStack changes
* Enabled using hardware floating-point unit for nrfconnect
platform
