### PR TITLE
Added generation of unique identifiers

### DIFF
--- a/config/nrfconnect/app/sample-defaults.conf
+++ b/config/nrfconnect/app/sample-defaults.conf
@@ -25,7 +25,6 @@ CONFIG_PRINTK_SYNC=y
 CONFIG_ASSERT=y
 CONFIG_HW_STACK_PROTECTION=y
 CONFIG_SHELL=y
-CONFIG_FPU=y
 
 # Enable getting reboot reasons information
 CONFIG_HWINFO=y

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -498,15 +498,17 @@ void DnssdServer::StartServer(Optional<Dnssd::CommissioningMode> mode)
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 CHIP_ERROR DnssdServer::GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize)
 {
-    char serialNumber[chip::DeviceLayer::ConfigurationManager::kMaxSerialNumberLength + 1];
+    uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+    size_t rotatingDeviceIdUniqueIdSize;
     uint16_t lifetimeCounter               = 0;
     size_t rotatingDeviceIdValueOutputSize = 0;
 
-    ReturnErrorOnFailure(chip::DeviceLayer::ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber)));
+    ReturnErrorOnFailure(chip::DeviceLayer::ConfigurationMgr().GetRotatingDeviceIdUniqueId(
+        rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueIdSize, sizeof(rotatingDeviceIdUniqueId)));
     ReturnErrorOnFailure(chip::DeviceLayer::ConfigurationMgr().GetLifetimeCounter(lifetimeCounter));
     return AdditionalDataPayloadGenerator().generateRotatingDeviceIdAsHexString(
-        lifetimeCounter, serialNumber, strlen(serialNumber), rotatingDeviceIdHexBuffer, rotatingDeviceIdHexBufferSize,
-        rotatingDeviceIdValueOutputSize);
+        lifetimeCounter, reinterpret_cast<char *>(rotatingDeviceIdUniqueId), rotatingDeviceIdUniqueIdSize,
+        rotatingDeviceIdHexBuffer, rotatingDeviceIdHexBufferSize, rotatingDeviceIdValueOutputSize);
 }
 #endif
 

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -268,6 +268,19 @@
 #define CHIP_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC 30
 #endif // CHIP_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC
 
+/**
+ * CHIP_DEVICE_CONFIG_TEST_ROTATING_DEVICE_ID_UNIQUE_ID
+ *
+ * Enables the use of a hard-coded default unique ID utilized for the rotating device ID calculation
+ * if none is found in Chip NV storage.
+ */
+#ifndef CHIP_DEVICE_CONFIG_TEST_ROTATING_DEVICE_ID_UNIQUE_ID
+#define CHIP_DEVICE_CONFIG_TEST_ROTATING_DEVICE_ID_UNIQUE_ID                                                                       \
+    {                                                                                                                              \
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff                             \
+    }
+#endif
+
 // -------------------- WiFi Station Configuration --------------------
 
 /**

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -71,7 +71,9 @@ public:
         kMaxProductLabelLength          = 64,
         kMaxSerialNumberLength          = 32,
         kMaxUniqueIDLength              = 32,
-
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+        kRotatingDeviceIDUniqueIDLength = 16,
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
         kPrimaryMACAddressLength = 8,
 #else
@@ -99,9 +101,14 @@ public:
     virtual CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount)                          = 0;
     virtual CHIP_ERROR GetSpake2pSalt(uint8_t * buf, size_t bufSize, size_t & saltLen)              = 0;
     virtual CHIP_ERROR GetSpake2pVerifier(uint8_t * buf, size_t bufSize, size_t & verifierLen)      = 0;
-    // Lifetime counter is monotonic counter that is incremented only in the case of a factory reset
-    virtual CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter)                  = 0;
-    virtual CHIP_ERROR IncrementLifetimeCounter()                                      = 0;
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    // Lifetime counter is monotonic counter that is incremented upon each commencement of advertising
+    virtual CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) = 0;
+    virtual CHIP_ERROR IncrementLifetimeCounter()                     = 0;
+    // Unique ID is identifier utilized for the rotating device ID calculation purpose as an input key. It is separate identifier
+    // from the Basic cluster unique ID.
+    virtual CHIP_ERROR GetRotatingDeviceIdUniqueId(uint8_t * buf, size_t & outSize, size_t bufSize) = 0;
+#endif
     virtual CHIP_ERROR GetRegulatoryLocation(uint8_t & location)                       = 0;
     virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)    = 0;
     virtual CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb)                            = 0;
@@ -129,6 +136,8 @@ public:
     virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
     virtual CHIP_ERROR GetReachable(bool & reachable)                                  = 0;
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
+    virtual CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen)        = 0;
+    virtual CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize)                    = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -27,6 +27,7 @@
 #define GENERIC_CONFIGURATION_MANAGER_IMPL_CPP
 
 #include <ble/CHIPBleServiceData.h>
+#include <crypto/RandUtils.h>
 #include <inttypes.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/Base64.h>
@@ -47,11 +48,24 @@ namespace Internal {
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
 {
+    CHIP_ERROR err;
+
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
 #endif
 
-    return CHIP_NO_ERROR;
+    char uniqueId[kMaxUniqueIDLength + 1];
+
+    // Generate Unique ID only if it is not present in the storage.
+    if (GetUniqueId(uniqueId, sizeof(uniqueId)) == CHIP_NO_ERROR)
+        return CHIP_NO_ERROR;
+
+    err = GenerateUniqueId(uniqueId, sizeof(uniqueId));
+    ReturnErrorOnFailure(err);
+
+    err = StoreUniqueId(uniqueId, strlen(uniqueId));
+
+    return err;
 }
 
 template <class ConfigClass>
@@ -493,29 +507,62 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetReachable(bool & rea
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf, size_t bufSize)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    CHIP_ERROR err;
+    size_t uniqueIdLen = 0; // without counting null-terminator
+    err                = ReadConfigValueStr(ConfigClass::kConfigKey_UniqueId, buf, bufSize, uniqueIdLen);
+
+    ReturnErrorOnFailure(err);
+
+    ReturnErrorCodeIf(uniqueIdLen >= bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(buf[uniqueIdLen] != 0, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    return err;
 }
 
 template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreUniqueId(const char * uniqueId, size_t uniqueIdLen)
+{
+    return WriteConfigValueStr(ConfigClass::kConfigKey_UniqueId, uniqueId, uniqueIdLen);
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GenerateUniqueId(char * buf, size_t bufSize)
+{
+    uint64_t randomUniqueId = Crypto::GetRandU64();
+    return Encoding::BytesToUppercaseHexString(reinterpret_cast<uint8_t *>(&randomUniqueId), sizeof(uint64_t), buf, bufSize);
+}
+
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
     lifetimeCounter = static_cast<uint16_t>(mLifetimePersistedCounter.GetValue());
     return CHIP_NO_ERROR;
-#else
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif
 }
 
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::IncrementLifetimeCounter()
 {
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
     return mLifetimePersistedCounter.Advance();
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetRotatingDeviceIdUniqueId(uint8_t * buf, size_t & outSize,
+                                                                                     size_t bufSize)
+{
+#ifdef CHIP_DEVICE_CONFIG_TEST_ROTATING_DEVICE_ID_UNIQUE_ID
+    uint8_t uniqueId[] = CHIP_DEVICE_CONFIG_TEST_ROTATING_DEVICE_ID_UNIQUE_ID;
+
+    ReturnErrorCodeIf(sizeof(uniqueId) > bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(sizeof(uniqueId) != kRotatingDeviceIDUniqueIDLength, CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(buf, uniqueId, sizeof(uniqueId));
+    outSize = sizeof(uniqueId);
+    return CHIP_NO_ERROR;
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
 }
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
 
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFailSafeArmed(bool & val)

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -81,8 +81,11 @@ public:
     CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount) override;
     CHIP_ERROR GetSpake2pSalt(uint8_t * buf, size_t bufSize, size_t & saltLen) override;
     CHIP_ERROR GetSpake2pVerifier(uint8_t * buf, size_t bufSize, size_t & verifierLen) override;
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
     CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override;
     CHIP_ERROR IncrementLifetimeCounter() override;
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(uint8_t * buf, size_t & outSize, size_t bufSize) override;
+#endif
     CHIP_ERROR GetFailSafeArmed(bool & val) override;
     CHIP_ERROR SetFailSafeArmed(bool val) override;
     CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override;
@@ -114,6 +117,8 @@ public:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
     CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
+    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR RunUnitTests(void) override;
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -77,6 +77,7 @@ const AmebaConfig::Key AmebaConfig::kConfigKey_OperationalDevicePrivateKey = { k
 const AmebaConfig::Key AmebaConfig::kConfigKey_RegulatoryLocation          = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const AmebaConfig::Key AmebaConfig::kConfigKey_UniqueId                    = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Keys stored in the Chip-counters namespace
 const AmebaConfig::Key AmebaConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -43,6 +43,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -1034,20 +1034,23 @@ void BLEManagerImpl::HandleC3CharRead(TBTCONFIG_CALLBACK_DATA * p_data)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     PacketBufferHandle bufferHandle;
-    char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1] = {};
-    uint16_t lifetimeCounter                                            = 0;
+    uint8_t rotatingDeviceIdUniqueId[ConfigurationManager::kRotatingDeviceIDUniqueIDLength] = {};
+    size_t rotatingDeviceIdUniqueIdSize;
+    uint16_t lifetimeCounter = 0;
     BitFlags<AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber));
+    err = ConfigurationMgr().GetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueIdSize,
+                                                         sizeof(rotatingDeviceIdUniqueId));
     SuccessOrExit(err);
     err = ConfigurationMgr().GetLifetimeCounter(lifetimeCounter);
     SuccessOrExit(err);
     additionalDataFields.Set(AdditionalDataFields::RotatingDeviceId);
 #endif /* CHIP_ENABLE_ROTATING_DEVICE_ID */
 
-    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(lifetimeCounter, serialNumber, strlen(serialNumber),
-                                                                         bufferHandle, additionalDataFields);
+    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(
+        lifetimeCounter, reinterpret_cast<char *>(rotatingDeviceIdUniqueId), rotatingDeviceIdUniqueIdSize, bufferHandle,
+        additionalDataFields);
     SuccessOrExit(err);
     p_data->msg_data.write.p_value = bufferHandle->Start();
     p_data->msg_data.write.len     = bufferHandle->DataLength();

--- a/src/platform/CYW30739/CYW30739Config.h
+++ b/src/platform/CYW30739/CYW30739Config.h
@@ -68,10 +68,11 @@ public:
     static constexpr Key kConfigKey_HourFormat         = 20;
     static constexpr Key kConfigKey_CalendarType       = 21;
     static constexpr Key kConfigKey_Breadcrumb         = 22;
+    static constexpr Key kConfigKey_UniqueId           = 23;
 
     // Set key id limits for each group.
     static constexpr Key kConfigKey_Base = kConfigKey_SerialNum;
-    static constexpr Key kConfigKey_Max  = kConfigKey_Breadcrumb;
+    static constexpr Key kConfigKey_Max  = kConfigKey_UniqueId;
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -69,6 +69,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const PosixConfig::Key PosixConfig::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -53,6 +53,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -102,6 +102,7 @@ public:
     static constexpr Key kConfigKey_WiFiSEC            = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
     static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0F);
     static constexpr Key kConfigKey_GroupKeyMax = EFR32ConfigKey(kChipConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
+    static constexpr Key kConfigKey_UniqueId    = EFR32ConfigKey(kChipFactory_KeyBase, 0x1F);
 
     // CHIP Counter Keys
     static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x00);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -75,6 +75,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const ESP32Config::Key ESP32Config::kConfigKey_UniqueId           = { kConfigNamespace_ChipFactory, "unique-id" };
 
 // Keys stored in the Chip-counters namespace
 const ESP32Config::Key ESP32Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -54,6 +54,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1068,12 +1068,14 @@ void BLEManagerImpl::HandleC3CharRead(struct ble_gatt_char_context * param)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferHandle bufferHandle;
 
-    char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1];
+    uint8_t rotatingDeviceIdUniqueId[ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+    size_t rotatingDeviceIdUniqueIdSize;
     uint16_t lifetimeCounter = 0;
     BitFlags<AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber));
+    err = ConfigurationMgr().GetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueIdSize,
+                                                         sizeof(rotatingDeviceIdUniqueId));
     SuccessOrExit(err);
     err = ConfigurationMgr().GetLifetimeCounter(lifetimeCounter);
     SuccessOrExit(err);
@@ -1081,8 +1083,9 @@ void BLEManagerImpl::HandleC3CharRead(struct ble_gatt_char_context * param)
     additionalDataFields.Set(AdditionalDataFields::RotatingDeviceId);
 #endif /* CHIP_ENABLE_ROTATING_DEVICE_ID */
 
-    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(lifetimeCounter, serialNumber, strlen(serialNumber),
-                                                                         bufferHandle, additionalDataFields);
+    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(
+        lifetimeCounter, reinterpret_cast<char *>(rotatingDeviceIdUniqueId), rotatingDeviceIdUniqueIdSize, bufferHandle,
+        additionalDataFields);
     SuccessOrExit(err);
 
     os_mbuf_append(param->ctxt->om, bufferHandle->Start(), bufferHandle->DataLength());

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -75,6 +75,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 const PosixConfig::Key PosixConfig::kConfigKey_LocationCapability = { kConfigNamespace_ChipConfig, "location-capability" };
+const PosixConfig::Key PosixConfig::kConfigKey_UniqueId           = { kConfigNamespace_ChipFactory, "unique-id" };
 
 // Keys stored in the Chip-counters namespace
 const PosixConfig::Key PosixConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -55,6 +55,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1197,12 +1197,14 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferHandle bufferHandle;
 
-    char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1];
+    uint8_t rotatingDeviceIdUniqueId[ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+    size_t rotatingDeviceIdUniqueIdSize;
     uint16_t lifetimeCounter = 0;
     BitFlags<AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber));
+    err = ConfigurationMgr().GetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueIdSize,
+                                                         sizeof(rotatingDeviceIdUniqueId));
     SuccessOrExit(err);
     err = ConfigurationMgr().GetLifetimeCounter(lifetimeCounter);
     SuccessOrExit(err);
@@ -1210,8 +1212,9 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     additionalDataFields.Set(AdditionalDataFields::RotatingDeviceId);
 #endif
 
-    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(lifetimeCounter, serialNumber, strlen(serialNumber),
-                                                                         bufferHandle, additionalDataFields);
+    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(
+        lifetimeCounter, reinterpret_cast<char *>(rotatingDeviceIdUniqueId), rotatingDeviceIdUniqueIdSize, bufferHandle,
+        additionalDataFields);
     SuccessOrExit(err);
 
     data = g_memdup(bufferHandle->Start(), bufferHandle->DataLength());

--- a/src/platform/P6/P6Config.cpp
+++ b/src/platform/P6/P6Config.cpp
@@ -77,6 +77,7 @@ const P6Config::Key P6Config::kConfigKey_WiFiSSID           = { kConfigNamespace
 const P6Config::Key P6Config::kConfigKey_WiFiPassword       = { kConfigNamespace_ChipConfig, "wifi-password" };
 const P6Config::Key P6Config::kConfigKey_WiFiSecurity       = { kConfigNamespace_ChipConfig, "wifi-security" };
 const P6Config::Key P6Config::kConfigKey_WiFiMode           = { kConfigNamespace_ChipConfig, "wifimode" };
+const P6Config::Key P6Config::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Keys stored in the Chip-counters namespace
 const P6Config::Key P6Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/P6/P6Config.h
+++ b/src/platform/P6/P6Config.h
@@ -55,6 +55,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -70,6 +70,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const PosixConfig::Key PosixConfig::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Tizen/PosixConfig.h
+++ b/src/platform/Tizen/PosixConfig.h
@@ -53,6 +53,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -587,12 +587,14 @@ CHIP_ERROR BLEManagerImpl::PrepareC3CharData()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1] = {};
-    uint16_t lifetimeCounter                                            = 0;
+    uint8_t rotatingDeviceIdUniqueId[ConfigurationManager::kRotatingDeviceIDUniqueIDLength] = {};
+    size_t rotatingDeviceIdUniqueIdSize;
+    uint16_t lifetimeCounter = 0;
     BitFlags<AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber));
+    err = ConfigurationMgr().GetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueIdSize,
+                                                         sizeof(rotatingDeviceIdUniqueId));
     SuccessOrExit(err);
     err = ConfigurationMgr().GetLifetimeCounter(lifetimeCounter);
     SuccessOrExit(err);
@@ -600,8 +602,9 @@ CHIP_ERROR BLEManagerImpl::PrepareC3CharData()
     additionalDataFields.Set(AdditionalDataFields::RotatingDeviceId);
 #endif
 
-    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(lifetimeCounter, serialNumber, strlen(serialNumber),
-                                                                         c3CharDataBufferHandle, additionalDataFields);
+    err = AdditionalDataPayloadGenerator().generateAdditionalDataPayload(
+        lifetimeCounter, reinterpret_cast<char *>(rotatingDeviceIdUniqueId), rotatingDeviceIdUniqueIdSize, c3CharDataBufferHandle,
+        additionalDataFields);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -74,6 +74,7 @@ const ZephyrConfig::Key ZephyrConfig::kConfigKey_FailSafeArmed      = CONFIG_KEY
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_RegulatoryLocation = CONFIG_KEY(NAMESPACE_CONFIG "regulatory-location");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_CountryCode        = CONFIG_KEY(NAMESPACE_CONFIG "country-code");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_Breadcrumb         = CONFIG_KEY(NAMESPACE_CONFIG "breadcrumb");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_UniqueId           = CONFIG_KEY(NAMESPACE_CONFIG "unique-id");
 
 // Keys stored in the counters namespace
 const ZephyrConfig::Key ZephyrConfig::kCounterKey_RebootCount           = CONFIG_KEY(NAMESPACE_COUNTERS "reboot-count");

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -44,6 +44,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -95,6 +95,7 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_WiFiStationSecType = { kConfi
 const AndroidConfig::Key AndroidConfig::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char AndroidConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -54,6 +54,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -63,6 +63,7 @@ public interface ConfigurationManager {
   String kConfigKey_RegulatoryLocation = "regulatory-location";
   String kConfigKey_CountryCode = "country-code";
   String kConfigKey_Breadcrumb = "breadcrumb";
+  String kConfigKey_UniqueId = "unique-id";
 
   // Prefix used for NVS keys that contain Chip group encryption keys.
   String kGroupKeyNamePrefix = "gk-";

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
@@ -93,6 +93,8 @@ const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_CountryCode        = 
                                                                              .itemID   = 0x001b } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_Breadcrumb         = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
                                                                             .itemID   = 0x001c } };
+const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_UniqueId           = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
+                                                                          .itemID   = 0x001d } };
 
 /* Internal for the KVS interface. */
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_KVS_key   = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
@@ -46,6 +46,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -66,8 +66,14 @@ private:
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
     CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR IncrementLifetimeCounter() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(uint8_t * buf, size_t & outSize, size_t bufSize) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+#endif
     CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override
@@ -102,6 +108,7 @@ private:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetReachable(bool & reachable) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if !defined(NDEBUG)
     CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -84,6 +84,7 @@ const MbedConfig::Key MbedConfig::kConfigKey_WiFiStationSecType = { CONFIG_KEY("
 const MbedConfig::Key MbedConfig::kConfigKey_RegulatoryLocation = { CONFIG_KEY("regulatory-location") };
 const MbedConfig::Key MbedConfig::kConfigKey_CountryCode        = { CONFIG_KEY("country-code") };
 const MbedConfig::Key MbedConfig::kConfigKey_Breadcrumb         = { CONFIG_KEY("breadcrumb") };
+const MbedConfig::Key MbedConfig::kConfigKey_UniqueId           = { CONFIG_KEY("unique-id") };
 
 CHIP_ERROR MbedConfig::ReadConfigValue(Key key, bool & val)
 {

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -52,6 +52,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.h
@@ -91,6 +91,7 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation = K32WConfigKey(kPDMId_ChipConfig, 0x07);
     static constexpr Key kConfigKey_CountryCode        = K32WConfigKey(kPDMId_ChipConfig, 0x08);
     static constexpr Key kConfigKey_Breadcrumb         = K32WConfigKey(kPDMId_ChipConfig, 0x09);
+    static constexpr Key kConfigKey_UniqueId           = K32WConfigKey(kPDMId_ChipConfig, 0x0A);
 
     // CHIP Counter Keys
     static constexpr Key kCounterKey_RebootCount           = K32WConfigKey(kPDMId_ChipCounter, 0x00);

--- a/src/platform/qpg/qpgConfig.h
+++ b/src/platform/qpg/qpgConfig.h
@@ -88,6 +88,7 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation = QorvoConfigKey(kFileId_ChipConfig, 0x09);
     static constexpr Key kConfigKey_CountryCode        = QorvoConfigKey(kFileId_ChipConfig, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = QorvoConfigKey(kFileId_ChipConfig, 0x0B);
+    static constexpr Key kConfigKey_UniqueId           = QorvoConfigKey(kFileId_ChipConfig, 0x0C);
 
     static constexpr Key kConfigKey_GroupKeyBase = QorvoConfigKey(kFileId_ChipConfig, 0x0F);
     static constexpr Key kConfigKey_GroupKeyMax  = QorvoConfigKey(kFileId_ChipConfig, 0x1E); // Allows 16 Group Keys to be created.

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -87,6 +87,32 @@ static void TestConfigurationMgr_SerialNumber(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, strcmp(buf, "89051") == 0);
 }
 
+static void TestConfigurationMgr_UniqueId(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    char buf[64];
+    const char * uniqueId = "67MXAZ012RT8UE";
+
+    err = ConfigurationMgr().StoreUniqueId(uniqueId, strlen(uniqueId));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetUniqueId(buf, 64);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, strlen(buf) == 14);
+    NL_TEST_ASSERT(inSuite, strcmp(buf, uniqueId) == 0);
+
+    err = ConfigurationMgr().StoreUniqueId(uniqueId, 7);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetUniqueId(buf, 64);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, strlen(buf) == 7);
+    NL_TEST_ASSERT(inSuite, strcmp(buf, "67MXAZ0") == 0);
+}
+
 static void TestConfigurationMgr_ManufacturingDate(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -237,6 +263,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test PlatformMgr::RunUnitTest", TestPlatformMgr_RunUnitTest),
 #endif
     NL_TEST_DEF("Test ConfigurationMgr::SerialNumber", TestConfigurationMgr_SerialNumber),
+    NL_TEST_DEF("Test ConfigurationMgr::UniqueId", TestConfigurationMgr_UniqueId),
     NL_TEST_DEF("Test ConfigurationMgr::ManufacturingDate", TestConfigurationMgr_ManufacturingDate),
     NL_TEST_DEF("Test ConfigurationMgr::HardwareVersion", TestConfigurationMgr_HardwareVersion),
     NL_TEST_DEF("Test ConfigurationMgr::SetupPinCode", TestConfigurationMgr_SetupPinCode),

--- a/src/setup_payload/AdditionalDataPayloadGenerator.h
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.h
@@ -51,8 +51,8 @@ public:
      * Generate additional data payload (i.e. TLV encoded).
      *
      * @param lifetimeCounter lifetime counter
-     * @param serialNumberBuffer null-terminated serial number buffer
-     * @param serialNumberBufferSize size of the serial number buffer supplied.
+     * @param uniqueIdBuffer unique id buffer
+     * @param uniqueIdBufferSize size of the unique id buffer supplied.
      * @param bufferHandle output buffer handle
      * @param additionalDataFields bitfield for what fields should be generated in the additional data
      *
@@ -69,28 +69,28 @@ public:
      *                              TLVBackingStore
      *
      */
-    CHIP_ERROR generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * serialNumberBuffer,
-                                             size_t serialNumberBufferSize, chip::System::PacketBufferHandle & bufferHandle,
+    CHIP_ERROR generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * uniqueIdBuffer, size_t uniqueIdBufferSize,
+                                             chip::System::PacketBufferHandle & bufferHandle,
                                              BitFlags<AdditionalDataFields> additionalDataFields);
     /**
      * Generate Rotating Device ID in Binary Format
      *
      * @param lifetimeCounter lifetime counter
-     * @param serialNumberBuffer null-terminated serial number buffer
-     * @param serialNumberBufferSize size of the serial number buffer supplied.
+     * @param uniqueIdBuffer unique id buffer
+     * @param uniqueIdBufferSize size of the unique id buffer supplied.
      * @param [in,out] rotatingDeviceIdBuffer as input, the buffer to use for
      *                 the binary data.  As output, will have its size set to
      *                 the actual size used upon successful generation
      */
-    CHIP_ERROR generateRotatingDeviceIdAsBinary(uint16_t lifetimeCounter, const char * serialNumberBuffer,
-                                                size_t serialNumberBufferSize, MutableByteSpan & rotatingDeviceIdBuffer);
+    CHIP_ERROR generateRotatingDeviceIdAsBinary(uint16_t lifetimeCounter, const char * uniqueIdBuffer, size_t uniqueIdBufferSize,
+                                                MutableByteSpan & rotatingDeviceIdBuffer);
 
     /**
      * Generate Device Rotating ID in String Format
      *
      * @param lifetimeCounter lifetime counter
-     * @param serialNumberBuffer null-terminated serial number buffer
-     * @param serialNumberBufferSize size of the serial number buffer supplied.
+     * @param uniqueIdBuffer unique id buffer
+     * @param uniqueIdBufferSize size of the unique id buffer supplied.
      * @param rotatingDeviceIdBuffer rotating device id buffer
      * @param rotatingDeviceIdBufferSize the current size of the supplied buffer
      * @param rotatingDeviceIdValueOutputSize the number of chars making up the actual value of the returned rotating device id
@@ -99,9 +99,9 @@ public:
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise.
      *
      */
-    CHIP_ERROR generateRotatingDeviceIdAsHexString(uint16_t lifetimeCounter, const char * serialNumberBuffer,
-                                                   size_t serialNumberBufferSize, char * rotatingDeviceIdBuffer,
-                                                   size_t rotatingDeviceIdBufferSize, size_t & rotatingDeviceIdValueOutputSize);
+    CHIP_ERROR generateRotatingDeviceIdAsHexString(uint16_t lifetimeCounter, const char * uniqueIdBuffer, size_t uniqueIdBufferSize,
+                                                   char * rotatingDeviceIdBuffer, size_t rotatingDeviceIdBufferSize,
+                                                   size_t & rotatingDeviceIdValueOutputSize);
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
Currently there are several problems related to the unique ids:
* There is no support for getting and storing unique id attribute from Basic cluster
* There is no support for getting unique id for rotating device id calculation purpose. That unique id is different one from
the Basic cluster unique id and is utilized as an input key for rotating device id generation algorithm
* Rotating device id is generated using serial number what is not compliant with the spec (it should be unique id)

#### Change overview
* Added methods to get and store unique id utilized in Basic cluster
* For all platforms added generic method generating random unique id utilized in Basic cluster
* Added `GetRotatingDeviceIdUniqueId` method for getting unique id utilized by rotating device id
* Replaced using serial number with unique id for generating rotating device id.
* Disabled CONFIG_FPU for nrfconnect platform, as it turned out to lead to MPU_FAULT and system crash on BLE C3 characteristic read

#### Testing

